### PR TITLE
Replace deprecated CORS library in App.jsx

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -17,7 +17,7 @@ function App() {
       <div className="app">
         <Helmet>
           <script
-            src="https://universal-editor-service.experiencecloud.live/corslib/LATEST"
+            src="https://universal-editor-service.adobe.io/cors.js"
             async
           />
           <meta


### PR DESCRIPTION
The current CORS library included in App.jsx is deprecated per https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/developing/universal-editor/developer-overview#ue-connect-remote-frame

This results in the Universal Editor being unable to load content. 

<img width="1514" height="590" alt="Screenshot 2025-08-15 at 11 26 40 AM" src="https://github.com/user-attachments/assets/af6a6eec-c450-43a7-b40a-e5d5b0ae929d" />

This update corrects the issue.